### PR TITLE
BPEL file should reference correct XSLT file in order to work.

### DIFF
--- a/src/main/tests/language-features/basic-activities/Assign-Copy-DoXslTransform.bpel
+++ b/src/main/tests/language-features/basic-activities/Assign-Copy-DoXslTransform.bpel
@@ -17,7 +17,7 @@
         <receive name="InitialReceive" createInstance="yes" partnerLink="MyRoleLink" operation="startProcessSync" portType="ti:TestInterfacePortType" variable="InitData"/>
         <assign name="AssignReplyData" >
             <copy>
-                <from>bpel:doXslTransform("echo.xsl", $InitData.inputPart)</from>
+                <from>bpel:doXslTransform("echo.xslt", $InitData.inputPart)</from>
                 <to variable="ReplyData" part="outputPart"/>
             </copy>
         </assign>


### PR DESCRIPTION
The `ASSIGN_COPY_DO_XSL_TRANSFORM` test case references a `echo.xsl` but the related file is named `echo.xslt`. This would explain why _all_ engines fail to run this test case...
