### PR TITLE
Enable more engines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
   - $HOME/.gradle/wrapper/
 
 env:
-  - JAVA7_HOME=/usr/lib/jvm/java7-openjdk-amd64/jre
+  - JAVA7_HOME=/usr/lib/jvm/java-7-openjdk-amd64/jre
 
 install:
   - TERM=dumb travis_retry ./gradlew assemble --info

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     internal 'org.json:json:5.0.5'
     internal 'org.apache.ant:ant-junit:1.9.6'
 
-    internal 'net.sf.saxon:Saxon-HE:9.6.0-7'
+    // requires 'net.sf.saxon:Saxon-HE' - we use the one that is shipped with soapUI
 
     internal 'com.mashape.unirest:unirest-java:1.4.7' // for http requests and responses
 

--- a/config.properties
+++ b/config.properties
@@ -3,7 +3,6 @@ partner.ipAndPort=localhost:2000
 downloads.dir=downloads
 
 java7.home=C:/Program Files/Java/jdk1.7.0_25
-jre7.home=C:/Program Files/Java/jre7
 
 maven.container=maven
 maven.home=maven/apache-maven-3.2.1

--- a/src/main/groovy/betsy/Main.java
+++ b/src/main/groovy/betsy/Main.java
@@ -31,6 +31,6 @@ public class Main {
     }
 
     private static void printUsage() {
-        System.out.println("The first argument must be either bpel or bpmn");
+        System.out.println("The first argument must be bpel, bpmn, engine or process");
     }
 }

--- a/src/main/groovy/betsy/bpel/engines/activebpel/ActiveBpelInstaller.java
+++ b/src/main/groovy/betsy/bpel/engines/activebpel/ActiveBpelInstaller.java
@@ -31,6 +31,8 @@ public class ActiveBpelInstaller {
         map.put("CATALINA_HOME", "../" + installer.getTomcat().getTomcatName());
 
         ConsoleTasks.executeOnWindows(ConsoleTasks.CliCommand.build(serverDir.resolve("activebpel-5.0.2"), "install.bat"), map);
+
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", serverDir.resolve("activebpel-5.0.2").resolve("install.sh").toString()));
         ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(serverDir.resolve("activebpel-5.0.2"), serverDir.resolve("activebpel-5.0.2").resolve("install.sh")), map);
     }
 }

--- a/src/main/groovy/betsy/bpel/engines/activebpel/ActiveBpelInstaller.java
+++ b/src/main/groovy/betsy/bpel/engines/activebpel/ActiveBpelInstaller.java
@@ -31,6 +31,6 @@ public class ActiveBpelInstaller {
         map.put("CATALINA_HOME", "../" + installer.getTomcat().getTomcatName());
 
         ConsoleTasks.executeOnWindows(ConsoleTasks.CliCommand.build(serverDir.resolve("activebpel-5.0.2"), "install.bat"), map);
-        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(serverDir.resolve("activebpel-5.0.2"), "install.sh"), map);
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(serverDir.resolve("activebpel-5.0.2"), serverDir.resolve("activebpel-5.0.2").resolve("install.sh")), map);
     }
 }

--- a/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
@@ -109,7 +109,7 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
         NetworkTasks.downloadFileFromBetsyRepo(filename);
         ZipTasks.unzip(Configuration.getDownloadsDir().resolve(filename), getServerPath());
 
-        FileTasks.createFile(getServerPath().resolve("start-openesb.bat"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && start openesb.bat");
+        FileTasks.createFile(getServerPath().resolve("start-openesb.bat"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && start \"OpenEsb 3.0.1 Standalone\" /min openesb.bat");
 
         // goto folder
         // start openesb
@@ -166,6 +166,8 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
     @Override
     public void shutdown() {
         ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), "openesb.bat").values("stop"));
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq OpenEsb 3.0.1 Standalone"));
+        
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), getInstanceBinFolder().resolve("openesb.sh")).values("stop"));
     }
 

--- a/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
@@ -109,7 +109,7 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
         NetworkTasks.downloadFileFromBetsyRepo(filename);
         ZipTasks.unzip(Configuration.getDownloadsDir().resolve(filename), getServerPath());
 
-        FileTasks.createFile(getServerPath().resolve("start-openesb.bat"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && start \"OpenEsb 3.0.1 Standalone\" /min openesb.bat");
+        FileTasks.createFile(getServerPath().resolve("start-openesb.bat"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && start \"" + getName() + "\" /min openesb.bat");
 
         // goto folder
         // start openesb
@@ -166,7 +166,7 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
     @Override
     public void shutdown() {
         ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), "openesb.bat").values("stop"));
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq OpenEsb 3.0.1 Standalone"));
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq " + getName()));
 
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), getInstanceBinFolder().resolve("openesb.sh")).values("stop"));
     }

--- a/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
@@ -111,7 +111,10 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
 
         FileTasks.createFile(getServerPath().resolve("start-openesb.bat"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && start openesb.bat");
 
-        FileTasks.createFile(getServerPath().resolve("start-openesb.sh"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && ./openesb.sh");
+        // goto folder
+        // start openesb
+        // put the process in the background
+        FileTasks.createFile(getServerPath().resolve("start-openesb.sh"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && ./openesb.sh &");
         ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getServerPath().resolve("start-openesb.sh").toString()));
         ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getInstanceBinFolder().resolve("openesb.sh").toString()));
     }

--- a/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
@@ -166,7 +166,7 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
     @Override
     public void shutdown() {
         ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), "openesb.bat").values("stop"));
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq " + getName()));
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq " + getName() + "*"));
 
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), getInstanceBinFolder().resolve("openesb.sh")).values("stop"));
     }

--- a/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
@@ -141,7 +141,7 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
     public void startup() {
         // start openesb.bat
         ConsoleTasks.executeOnWindows(ConsoleTasks.CliCommand.build(getServerPath(), "start-openesb.bat"));
-        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getServerPath(), "start-openesb.sh"));
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getServerPath(), getServerPath().resolve("start-openesb.sh").toAbsolutePath()));
         WaitTasks.waitForAvailabilityOfUrl(10 * 1000, 500, WEB_UI);
 
         // install bpelse
@@ -163,7 +163,7 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
     @Override
     public void shutdown() {
         ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), "openesb.bat").values("stop"));
-        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), "openesb.sh").values("stop"));
+        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), getInstanceBinFolder().resolve("openesb.sh")).values("stop"));
     }
 
     @Override

--- a/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
@@ -162,8 +162,8 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
 
     @Override
     public void shutdown() {
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getServerPath(), "openesb.bat").values("stop"));
-        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getServerPath(), "openesb.sh").values("stop"));
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), "openesb.bat").values("stop"));
+        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), "openesb.sh").values("stop"));
     }
 
     @Override

--- a/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
@@ -110,7 +110,10 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
         ZipTasks.unzip(Configuration.getDownloadsDir().resolve(filename), getServerPath());
 
         FileTasks.createFile(getServerPath().resolve("start-openesb.bat"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && start openesb.bat");
+
         FileTasks.createFile(getServerPath().resolve("start-openesb.sh"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && ./openesb.sh");
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getServerPath().resolve("start-openesb.sh").toString()));
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getInstanceBinFolder().resolve("openesb.sh").toString()));
     }
 
     private Path getInstanceBinFolder() {

--- a/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
@@ -167,7 +167,7 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
     public void shutdown() {
         ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), "openesb.bat").values("stop"));
         ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq OpenEsb 3.0.1 Standalone"));
-        
+
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getInstanceBinFolder(), getInstanceBinFolder().resolve("openesb.sh")).values("stop"));
     }
 

--- a/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
@@ -159,7 +159,8 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
 
     @Override
     public void shutdown() {
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq C:\\Windows\\system32\\cmd.exe - openesb.bat"));
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getServerPath(), "openesb.bat").values("stop"));
+        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getServerPath(), "openesb.sh").values("stop"));
     }
 
     @Override

--- a/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/openesb/OpenEsb301StandaloneEngine.java
@@ -114,7 +114,7 @@ public class OpenEsb301StandaloneEngine extends AbstractLocalBPELEngine {
         // goto folder
         // start openesb
         // put the process in the background
-        FileTasks.createFile(getServerPath().resolve("start-openesb.sh"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && ./openesb.sh &");
+        FileTasks.createFile(getServerPath().resolve("start-openesb.sh"), "cd \"" + getInstanceBinFolder().toAbsolutePath() + "\" && ./openesb.sh >/dev/null 2>&1 &");
         ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getServerPath().resolve("start-openesb.sh").toString()));
         ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getInstanceBinFolder().resolve("openesb.sh").toString()));
     }

--- a/src/main/groovy/betsy/bpel/engines/petalsesb/PetalsEsbEngine.java
+++ b/src/main/groovy/betsy/bpel/engines/petalsesb/PetalsEsbEngine.java
@@ -65,7 +65,6 @@ public class PetalsEsbEngine extends AbstractLocalBPELEngine {
     @Override
     public void startup() {
         Path pathToJava7 = Configuration.getJava7Home();
-        FileTasks.assertDirectory(pathToJava7);
         Map<String,String> environment = new HashMap<>();
         environment.put("JAVA_HOME", pathToJava7.toString());
         ConsoleTasks.executeOnWindows(ConsoleTasks.CliCommand.build(getPetalsBinFolder(), "petals-esb.bat"), environment);

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Deployer.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Deployer.java
@@ -24,7 +24,7 @@ public class Wso2Deployer {
         FileTasks.copyFileIntoFolder(file, deploymentDir);
 
         WaitTasks.waitFor(120_000, 500, () ->
-                FileTasks.hasFileSpecificSubstring(logsDir.resolve("wso2carbon.log"), "{org.apache.ode.bpel.engine.BpelServerImpl} -  Registered process") ||
+                FileTasks.hasFileSpecificSubstring(logsDir.resolve("wso2carbon.log"), "{org.apache.ode.bpel.engine.BpelServerImpl} -  Registered process {http://dsg.wiai.uniba.de/betsy") ||
                 FileTasks.hasFileSpecificSubstring(logsDir.resolve("wso2carbon.log"), "org.apache.axis2.deployment.DeploymentException: Error deploying BPEL package: " + file.getFileName().toString() + " {org.apache.axis2.deployment.DeploymentEngine}")
         );
         WaitTasks.sleep(2_000);

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v2_1_2.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v2_1_2.java
@@ -19,9 +19,20 @@ public class Wso2Engine_v2_1_2 extends Wso2Engine_v3_1_0 {
     public void install() {
         super.install();
 
-        Path startupScript = getBinDir().resolve("wso2server.bat");
-        FileTasks.deleteLine(startupScript, 150);
-        FileTasks.deleteLine(startupScript, 150);
+        Path windowsStartupScript = getBinDir().resolve("wso2server.bat");
+        FileTasks.deleteLine(windowsStartupScript, 150);
+        FileTasks.deleteLine(windowsStartupScript, 150);
+
+
+        Path unixStartupScript = getBinDir().resolve("wso2server.sh");
+        FileTasks.deleteLine(unixStartupScript, 217);
+        FileTasks.deleteLine(unixStartupScript, 217);
+        FileTasks.deleteLine(unixStartupScript, 217);
+        FileTasks.deleteLine(unixStartupScript, 217);
+        FileTasks.deleteLine(unixStartupScript, 217);
+        FileTasks.deleteLine(unixStartupScript, 217);
+        FileTasks.deleteLine(unixStartupScript, 217);
+
     }
 
     @Override

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -39,7 +39,8 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
         FileTasks.createFile(getServerPath().resolve("startup.bat"), "start startup-helper.bat");
         FileTasks.createFile(getServerPath().resolve("startup-helper.bat"), "TITLE wso2server\ncd " +
                 getBinDir().toAbsolutePath() + " && call wso2server.bat");
-        FileTasks.createFile(getServerPath().resolve("startup.sh"), "cd " + getBinDir().toAbsolutePath() + " && ./wso2server.bat");
+
+        FileTasks.createFile(getServerPath().resolve("startup.sh"), "cd " + getBinDir().toAbsolutePath() + " && ./wso2server.sh");
     }
 
     public String getZipFileName() {
@@ -49,7 +50,9 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
     @Override
     public void startup() {
         ConsoleTasks.executeOnWindows(ConsoleTasks.CliCommand.build(getServerPath(), "startup.bat"));
-        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getServerPath(), "startup.sh"));
+
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getServerPath().resolve("startup.sh").toString()));
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getServerPath(), getServerPath().resolve("startup.sh")));
         WaitTasks.sleep(2000);
         WaitTasks.waitForSubstringInFile(120_000, 500, getLogsFolder().resolve("wso2carbon.log"), "WSO2 Carbon started in ");
     }
@@ -72,6 +75,8 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
 
         // required for jenkins - may have side effects but this should not be a problem in this context
         ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq Administrator:*"));
+
+        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.sh")).values("--stop"));
     }
 
     @Override

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -51,7 +51,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
     public void startup() {
         ConsoleTasks.executeOnWindows(ConsoleTasks.CliCommand.build(getServerPath(), "startup.bat"));
 
-        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getServerPath(), getServerPath().resolve("wso2server.sh")).values("start")); // start wso2 in background
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.sh")).values("start")); // start wso2 in background
         WaitTasks.sleep(2000);
         WaitTasks.waitForSubstringInFile(120_000, 500, getLogsFolder().resolve("wso2carbon.log"), "WSO2 Carbon started in ");
     }

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -70,7 +70,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
 
     @Override
     public void shutdown() {
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq " + getName()));
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq " + getName() + "*"));
 
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir(), getBinDir().resolve("wso2server.sh")).values("stop"));
     }

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -36,9 +36,8 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
 
         ZipTasks.unzip(Configuration.getDownloadsDir().resolve(fileName), getServerPath());
 
-        FileTasks.createFile(getServerPath().resolve("startup.bat"), "start startup-helper.bat");
-        FileTasks.createFile(getServerPath().resolve("startup-helper.bat"), "TITLE wso2server\ncd " +
-                getBinDir().toAbsolutePath() + " && call wso2server.bat");
+        FileTasks.createFile(getServerPath().resolve("startup.bat"), "start \"" + getName() + "\" /min startup-helper.bat");
+        FileTasks.createFile(getServerPath().resolve("startup-helper.bat"), "cd " + getBinDir().toAbsolutePath() + " && call wso2server.bat");
 
         ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getBinDir().resolve("wso2server.sh").toString()));
     }
@@ -70,10 +69,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
 
     @Override
     public void shutdown() {
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq wso2server"));
-        // required for jenkins - may have side effects but this should not be a problem in this context
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq Administrator:*"));
-
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq " + getName()));
 
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.sh")).values("stop"));
     }

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -50,7 +50,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
     public void startup() {
         ConsoleTasks.executeOnWindows(ConsoleTasks.CliCommand.build(getServerPath(), "startup.bat"));
 
-        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.sh")).values("start")); // start wso2 in background
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getBinDir(), getBinDir().resolve("wso2server.sh")).values("start")); // start wso2 in background
         WaitTasks.sleep(2000);
         WaitTasks.waitForSubstringInFile(120_000, 500, getLogsFolder().resolve("wso2carbon.log"), "WSO2 Carbon started in ");
     }
@@ -71,7 +71,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
     public void shutdown() {
         ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq " + getName()));
 
-        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.sh")).values("stop"));
+        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir(), getBinDir().resolve("wso2server.sh")).values("stop"));
     }
 
     @Override

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -40,6 +40,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
         FileTasks.createFile(getServerPath().resolve("startup-helper.bat"), "TITLE wso2server\ncd " +
                 getBinDir().toAbsolutePath() + " && call wso2server.bat");
 
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getBinDir().resolve("wso2server.sh").toString()));
         FileTasks.createFile(getServerPath().resolve("startup.sh"), "cd " + getBinDir().toAbsolutePath() + " && ./wso2server.sh");
     }
 

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -70,8 +70,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
 
     @Override
     public void shutdown() {
-        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.bat")).values("--stop"));
-
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.bat")).values("stop"));
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.sh")).values("stop"));
     }
 

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -39,7 +39,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
         FileTasks.createFile(getServerPath().resolve("startup.bat"), "start \"" + getName() + "\" /min startup-helper.bat");
         FileTasks.createFile(getServerPath().resolve("startup-helper.bat"), "cd " + getBinDir().toAbsolutePath() + " && call wso2server.bat");
 
-        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getBinDir().resolve("wso2server.sh").toString()));
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("--recursive", "777", getServerPath().toString()));
     }
 
     public String getZipFileName() {

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -72,11 +72,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
 
     @Override
     public void shutdown() {
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq wso2server"));
-
-        // required for jenkins - may have side effects but this should not be a problem in this context
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq Administrator:*"));
-
+        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.bat")).values("--stop"));
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.sh")).values("--stop"));
     }
 

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -41,7 +41,6 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
                 getBinDir().toAbsolutePath() + " && call wso2server.bat");
 
         ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getBinDir().resolve("wso2server.sh").toString()));
-        FileTasks.createFile(getServerPath().resolve("startup.sh"), "cd " + getBinDir().toAbsolutePath() + " && ./wso2server.sh");
     }
 
     public String getZipFileName() {
@@ -52,8 +51,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
     public void startup() {
         ConsoleTasks.executeOnWindows(ConsoleTasks.CliCommand.build(getServerPath(), "startup.bat"));
 
-        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getServerPath().resolve("startup.sh").toString()));
-        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getServerPath(), getServerPath().resolve("startup.sh")).values("&")); // start wso2 in background
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getServerPath(), getServerPath().resolve("wso2server.sh")).values("start")); // start wso2 in background
         WaitTasks.sleep(2000);
         WaitTasks.waitForSubstringInFile(120_000, 500, getLogsFolder().resolve("wso2carbon.log"), "WSO2 Carbon started in ");
     }
@@ -73,7 +71,8 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
     @Override
     public void shutdown() {
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.bat")).values("--stop"));
-        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.sh")).values("--stop"));
+
+        ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.sh")).values("stop"));
     }
 
     @Override

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -53,7 +53,7 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
         ConsoleTasks.executeOnWindows(ConsoleTasks.CliCommand.build(getServerPath(), "startup.bat"));
 
         ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("+x", getServerPath().resolve("startup.sh").toString()));
-        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getServerPath(), getServerPath().resolve("startup.sh")));
+        ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getServerPath(), getServerPath().resolve("startup.sh")).values("&")); // start wso2 in background
         WaitTasks.sleep(2000);
         WaitTasks.waitForSubstringInFile(120_000, 500, getLogsFolder().resolve("wso2carbon.log"), "WSO2 Carbon started in ");
     }

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -70,7 +70,11 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
 
     @Override
     public void shutdown() {
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.bat")).values("stop"));
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq wso2server"));
+        // required for jenkins - may have side effects but this should not be a problem in this context
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq Administrator:*"));
+
+
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getBinDir().resolve("wso2server.sh")).values("stop"));
     }
 

--- a/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
+++ b/src/main/groovy/betsy/bpel/engines/wso2/Wso2Engine_v3_1_0.java
@@ -49,10 +49,11 @@ public class Wso2Engine_v3_1_0 extends AbstractLocalBPELEngine {
     @Override
     public void startup() {
         ConsoleTasks.executeOnWindows(ConsoleTasks.CliCommand.build(getServerPath(), "startup.bat"));
-
         ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build(getBinDir(), getBinDir().resolve("wso2server.sh")).values("start")); // start wso2 in background
         WaitTasks.sleep(2000);
-        WaitTasks.waitForSubstringInFile(120_000, 500, getLogsFolder().resolve("wso2carbon.log"), "WSO2 Carbon started in ");
+
+        Path logFile = getLogsFolder().resolve("wso2carbon.log");
+        WaitTasks.waitFor(120_000, 500, () -> FileTasks.hasFile(logFile) && FileTasks.hasFileSpecificSubstring(logFile, "WSO2 Carbon started in "));
     }
 
     public Path getLogsFolder() {

--- a/src/main/groovy/betsy/bpmn/engines/camunda/CamundaEngine.java
+++ b/src/main/groovy/betsy/bpmn/engines/camunda/CamundaEngine.java
@@ -124,7 +124,6 @@ public class CamundaEngine extends AbstractBPMNEngine {
     @Override
     public void startup() {
         Path pathToJava7 = Configuration.getJava7Home();
-        FileTasks.assertDirectory(pathToJava7);
 
         Map<String, String> map = new LinkedHashMap<>(2);
         map.put("JAVA_HOME", pathToJava7.toString());

--- a/src/main/groovy/betsy/bpmn/engines/camunda/CamundaEngine.java
+++ b/src/main/groovy/betsy/bpmn/engines/camunda/CamundaEngine.java
@@ -126,17 +126,14 @@ public class CamundaEngine extends AbstractBPMNEngine {
         Path pathToJava7 = Configuration.getJava7Home();
         FileTasks.assertDirectory(pathToJava7);
 
-        Path pathToJre7 = Configuration.getJre7Home();
-        FileTasks.assertDirectory(pathToJre7);
-
         Map<String, String> map = new LinkedHashMap<>(2);
         map.put("JAVA_HOME", pathToJava7.toString());
-        map.put("JRE_HOME", pathToJre7.toString());
+        map.put("JRE_HOME", pathToJava7.toString());
         ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build(getServerPath(), "camunda_startup.bat"), map);
 
         Map<String, String> map1 = new LinkedHashMap<>(2);
         map1.put("JAVA_HOME", pathToJava7.toString());
-        map1.put("JRE_HOME", pathToJre7.toString());
+        map1.put("JRE_HOME", pathToJava7.toString());
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(getServerPath().resolve("camunda_startup.sh")), map1);
 
         WaitTasks.waitForAvailabilityOfUrl(30_000, 500, getCamundaUrl());

--- a/src/main/groovy/betsy/bpmn/engines/jbpm/JbpmEngine.java
+++ b/src/main/groovy/betsy/bpmn/engines/jbpm/JbpmEngine.java
@@ -121,7 +121,6 @@ public class JbpmEngine extends AbstractBPMNEngine {
     @Override
     public void startup() {
         Path pathToJava7 = Configuration.getJava7Home();
-        FileTasks.assertDirectory(pathToJava7);
 
         ConsoleTasks.setupAnt(getAntPath());
 

--- a/src/main/groovy/betsy/common/config/Configuration.java
+++ b/src/main/groovy/betsy/common/config/Configuration.java
@@ -142,34 +142,6 @@ public class Configuration {
         return java7home;
     }
 
-    public static Path getJre7Home() {
-        // Trying to determine JDK7 Path using SysEnv
-        String jre7env = System.getenv("JRE7_HOME");
-        Path result;
-
-        if (jre7env == null) {
-            // Fallback to properties file
-            result = Paths.get(PROPERTIES.getProperty("jre7.home"));
-        } else {
-            result = Paths.get(jre7env);
-        }
-
-        if (!Files.isDirectory(result)) {
-            log.info("Found [" + result + "] for key [jre7.home] " + "Path to JRE_HOME, but the directory does not exist! -> trying JDK7 HOME");
-
-
-            Path jreInJava7Home = getJava7Home().resolve("jre");
-
-            if(!Files.isDirectory(jreInJava7Home)) {
-                throw new ConfigurationException("No JRE of Java 7 could be found!");
-            }
-
-            result = jreInJava7Home;
-        }
-
-        return result;
-    }
-
     private static final Logger log = Logger.getLogger(Configuration.class);
 
 }

--- a/src/main/groovy/betsy/common/engines/tomcat/Tomcat.java
+++ b/src/main/groovy/betsy/common/engines/tomcat/Tomcat.java
@@ -101,7 +101,6 @@ public class Tomcat {
             return Collections.emptyMap();
         } else {
             Path pathToJava7 = Configuration.getJava7Home();
-            FileTasks.assertDirectory(pathToJava7);
             Map<String, String> environment = new HashMap<>();
             environment.put("JAVA_HOME", pathToJava7.toString());
             return environment;

--- a/src/main/groovy/betsy/common/engines/tomcat/Tomcat.java
+++ b/src/main/groovy/betsy/common/engines/tomcat/Tomcat.java
@@ -111,7 +111,7 @@ public class Tomcat {
      * Shutdown the tomcat if running.
      */
     public void shutdown() {
-        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq Tomcat"));
+        ConsoleTasks.executeOnWindowsAndIgnoreError(ConsoleTasks.CliCommand.build("taskkill").values("/FI", "WINDOWTITLE eq " + getTomcatName() + "*"));
         ConsoleTasks.executeOnUnixAndIgnoreError(ConsoleTasks.CliCommand.build(parentFolder.resolve("tomcat_shutdown.sh")));
     }
 

--- a/src/main/groovy/betsy/common/engines/tomcat/TomcatInstaller.java
+++ b/src/main/groovy/betsy/common/engines/tomcat/TomcatInstaller.java
@@ -39,7 +39,7 @@ public class TomcatInstaller {
         ZipTasks.unzip(Configuration.getDownloadsDir().resolve(fileName), destinationDir);
 
         FileTasks.createFile(destinationDir.resolve("tomcat_startup.bat"), "SET CATALINA_OPTS=-Xmx3048M -XX:MaxPermSize=2048m " +
-                additionalVmParam + "\ncd " + getTomcat().getTomcatBinDir().toAbsolutePath() + " && call startup.bat");
+                additionalVmParam + "\ncd " + getTomcat().getTomcatBinDir().toAbsolutePath() + " && start \"" + getTomcatName() + "\" /min startup.bat");
         FileTasks.createFile(destinationDir.resolve("tomcat_shutdown.bat"), "cd " +
                 getTomcat().getTomcatBinDir().toAbsolutePath() + " && call shutdown.bat");
 
@@ -50,6 +50,8 @@ public class TomcatInstaller {
                 getTomcat().getTomcatBinDir().toAbsolutePath() + " && ./shutdown.sh");
 
         ConsoleTasks.executeOnUnix(ConsoleTasks.CliCommand.build("chmod").values("--recursive", "777", destinationDir.toAbsolutePath().toString()));
+
+        FileTasks.replaceLine(getTomcat().getTomcatBinDir().resolve("startup.bat"), "call \"%EXECUTABLE%\" start %CMD_LINE_ARGS%", "call \"%EXECUTABLE%\" run %CMD_LINE_ARGS%");
     }
 
     public Tomcat getTomcat() {

--- a/src/main/groovy/betsy/common/tasks/FileTasks.java
+++ b/src/main/groovy/betsy/common/tasks/FileTasks.java
@@ -129,6 +129,37 @@ public class FileTasks {
         }
     }
 
+    public static void replaceLine(Path path, String oldContent, String newLineContent) {
+        LOGGER.info("Replacing contents of a line which has exactly " + oldContent + " from file " + path.toAbsolutePath() + " with the new content " + newLineContent);
+
+        try {
+            // line numbers start with 1, not with 0!
+            List<String> lines = Files.readAllLines(path, StandardCharsets.UTF_8);
+            LOGGER.info("File has " + lines.size() + " lines");
+
+            int index = findIndex(oldContent, lines);
+            if(index == -1) {
+                throw new IllegalStateException("Could not find a line with content [" + oldContent + "] in file " + path);
+            }
+
+            lines.set(index, newLineContent);
+
+            Files.write(path, lines, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not replace line in file " + path, e);
+        }
+    }
+
+    private static int findIndex(String oldContent, List<String> lines) {
+        int line = -1;
+        for(int i = 0; i < lines.size(); i++) {
+            if(lines.get(i).trim().equals(oldContent)) {
+                line = i;
+            }
+        }
+        return line;
+    }
+
     public static void deleteFile(Path file) {
         LOGGER.info("Deleting file " + file.toAbsolutePath());
 

--- a/src/main/groovy/betsy/common/tasks/WaitTasks.java
+++ b/src/main/groovy/betsy/common/tasks/WaitTasks.java
@@ -40,7 +40,8 @@ public class WaitTasks {
         try {
             while (max > System.currentTimeMillis()) {
                 if (c.call()) {
-                    LOGGER.info("Condition of wait task was met -> proceeding");
+                    long work = max - System.currentTimeMillis();
+                    LOGGER.info("Condition of wait task was met in " + work + "/" + max + "ms -> proceeding");
                     return;
                 }
                 sleepInternal(checkEveryMilliseconds);

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -90,7 +90,7 @@ public class SystemTest {
         testBPELEngine("bpelg-in-memory");
     }
 
-    @Test @Ignore
+    @Test @Ignore("does not work on *nix when starting in the background as a deamon service")
     public void test_B4_BpelWso212Sequence() throws IOException, InterruptedException {
         testBPELEngine("wso2_v2_1_2");
     }

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -59,6 +59,11 @@ public class SystemTest {
         testBPELEngine("bpelg");
     }
 
+    @Test
+    public void test_B3_BpelBpelgInMemSequence() throws IOException, InterruptedException {
+        testBPELEngine("bpelg-in-memory");
+    }
+
     @Ignore
     @Test
     public void test_B4_BpelWso320Sequence() throws IOException, InterruptedException {

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -91,6 +91,22 @@ public class SystemTest {
     }
 
     @Test
+    public void test_B4_BpelWso212Sequence() throws IOException, InterruptedException {
+        testBPELEngine("wso2_v2_1_2");
+    }
+
+    @Test
+    public void test_B4_BpelWso300Sequence() throws IOException, InterruptedException {
+        testBPELEngine("wso2_v3_0_0");
+    }
+
+
+    @Test
+    public void test_B4_BpelWso310Sequence() throws IOException, InterruptedException {
+        testBPELEngine("wso2_v3_1_0");
+    }
+
+    @Test
     public void test_B4_BpelWso320Sequence() throws IOException, InterruptedException {
         testBPELEngine("wso2_v3_2_0");
     }

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -90,7 +90,7 @@ public class SystemTest {
         testBPELEngine("bpelg-in-memory");
     }
 
-    @Test
+    @Test @Ignore
     public void test_B4_BpelWso212Sequence() throws IOException, InterruptedException {
         testBPELEngine("wso2_v2_1_2");
     }
@@ -99,7 +99,6 @@ public class SystemTest {
     public void test_B4_BpelWso300Sequence() throws IOException, InterruptedException {
         testBPELEngine("wso2_v3_0_0");
     }
-
 
     @Test
     public void test_B4_BpelWso310Sequence() throws IOException, InterruptedException {

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -17,16 +17,37 @@ public class SystemTest {
 
     @Test
     public void test_A_BpmnActivitiSequenceFlow() throws IOException {
-        Main.main("bpmn", "-f", "test-activiti", "activiti", "SequenceFlow");
+        testBPMNEngine("activiti");
+    }
 
-        assertEquals("[SequenceFlow;activiti;basics;1;0;1;1]", Files.readAllLines(Paths.get("test-activiti/reports/results.csv")).toString());
+    @Test
+    public void test_A_BpmnActiviti5170SequenceFlow() throws IOException {
+        testBPMNEngine("activiti5170");
+    }
+
+    @Test
+    public void test_A_BpmnCamunda700SequenceFlow() throws IOException {
+        testBPMNEngine("camunda");
+    }
+
+    @Test
+    public void test_A_BpmnCamunda710SequenceFlow() throws IOException {
+        testBPMNEngine("camunda710");
     }
 
     @Test
     public void test_A_BpmnCamunda720SequenceFlow() throws IOException {
-        Main.main("bpmn", "-f", "test-camunda720", "camunda720", "SequenceFlow");
+        testBPMNEngine("camunda720");
+    }
 
-        assertEquals("[SequenceFlow;camunda720;basics;1;0;1;1]", Files.readAllLines(Paths.get("test-camunda720/reports/results.csv")).toString());
+    @Test
+    public void test_A_BpmnCamunda730SequenceFlow() throws IOException {
+        testBPMNEngine("camunda730");
+    }
+
+    private void testBPMNEngine(String engine) throws IOException {
+        Main.main("bpmn", "-f", "test-" + engine, engine, "SequenceFlow");
+        assertEquals("[SequenceFlow;" + engine + ";basics;1;0;1;1]", Files.readAllLines(Paths.get("test-" + engine + "/reports/results.csv")).toString());
     }
 
     @Test

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -31,43 +31,50 @@ public class SystemTest {
 
     @Test
     public void test_B1_BpelOdeSequence() throws IOException, InterruptedException {
-        BPELMain.shutdownSoapUiAfterCompletion(false);
-        BPELMain.main("ode", "sequence", "-f", "test-ode");
+        testBPELEngine("ode");
+    }
 
-        assertEquals("[Sequence;ode;structured;1;0;1;1]", Files.readAllLines(Paths.get("test-ode/reports/results.csv")).toString());
+    @Test
+    public void test_B1_BpelOdeInMemSequence() throws IOException, InterruptedException {
+        testBPELEngine("ode-in-memory");
+    }
+
+    @Test
+    public void test_B1_BpelOde136Sequence() throws IOException, InterruptedException {
+        testBPELEngine("ode136");
+    }
+
+    @Test
+    public void test_B1_BpelOde136InMemorySequence() throws IOException, InterruptedException {
+        testBPELEngine("ode136-in-memory");
     }
 
     @Test
     public void test_B2_BpelOrchestraSequence() throws IOException, InterruptedException {
-        BPELMain.shutdownSoapUiAfterCompletion(false);
-        BPELMain.main("orchestra", "sequence", "-f", "test-orchestra");
-
-        assertEquals("[Sequence;orchestra;structured;1;0;1;1]", Files.readAllLines(Paths.get("test-orchestra/reports/results.csv")).toString());
+        testBPELEngine("orchestra");
     }
 
     @Test
     public void test_B3_BpelBpelgSequence() throws IOException, InterruptedException {
-        BPELMain.shutdownSoapUiAfterCompletion(false);
-        BPELMain.main("bpelg", "sequence", "-f", "test-bpelg");
-
-        assertEquals("[Sequence;bpelg;structured;1;0;1;1]", Files.readAllLines(Paths.get("test-bpelg/reports/results.csv")).toString());
+        testBPELEngine("bpelg");
     }
 
     @Ignore
     @Test
     public void test_B4_BpelWso320Sequence() throws IOException, InterruptedException {
-        BPELMain.shutdownSoapUiAfterCompletion(true);
-        BPELMain.main("wso2_v3_2_0", "sequence", "-f", "test-wso320");
-
-        assertEquals("[Sequence;wso2_v3_2_0;structured;1;0;1;1]", Files.readAllLines(Paths.get("test-wso320/reports/results.csv")).toString());
+        testBPELEngine("wso2_v3_2_0");
     }
 
     @Test
     public void test_B5_BpelActiveBpelSequence() throws IOException, InterruptedException {
+        testBPELEngine("active-bpel");
         BPELMain.shutdownSoapUiAfterCompletion(true);
-        BPELMain.main("active-bpel", "sequence", "-f", "test-active-bpel");
+    }
 
-        assertEquals("[Sequence;active-bpel;structured;1;0;1;1]", Files.readAllLines(Paths.get("test-active-bpel/reports/results.csv")).toString());
+    private void testBPELEngine(String engine) throws IOException {
+        BPELMain.shutdownSoapUiAfterCompletion(false);
+        BPELMain.main(engine, "sequence", "-f", "test-" + engine);
+        assertEquals("[Sequence;" + engine + ";structured;1;0;1;1]", Files.readAllLines(Paths.get("test-" + engine + "/reports/results.csv")).toString());
     }
 
 }

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -90,7 +90,6 @@ public class SystemTest {
         testBPELEngine("bpelg-in-memory");
     }
 
-    @Ignore
     @Test
     public void test_B4_BpelWso320Sequence() throws IOException, InterruptedException {
         testBPELEngine("wso2_v3_2_0");

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -112,7 +112,12 @@ public class SystemTest {
     }
 
     @Test
-    public void test_B5_BpelActiveBpelSequence() throws IOException, InterruptedException {
+    public void test_B5_BpelOpenesb301StandaloneSequence() throws IOException, InterruptedException {
+        testBPELEngine("openesb301standalone");
+    }
+
+    @Test
+    public void test_B6_BpelActiveBpelSequence() throws IOException, InterruptedException {
         testBPELEngine("active-bpel");
         BPELMain.shutdownSoapUiAfterCompletion(true);
     }

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -81,6 +81,11 @@ public class SystemTest {
     }
 
     @Test
+    public void test_B3_BpelBpelgInvokeSync() throws IOException, InterruptedException {
+        testBPELEngine("bpelg", "Invoke-Sync");
+    }
+
+    @Test
     public void test_B3_BpelBpelgInMemSequence() throws IOException, InterruptedException {
         testBPELEngine("bpelg-in-memory");
     }
@@ -98,9 +103,13 @@ public class SystemTest {
     }
 
     private void testBPELEngine(String engine) throws IOException {
+        testBPELEngine(engine, "Sequence");
+    }
+
+    private void testBPELEngine(String engine, String process) throws IOException {
         BPELMain.shutdownSoapUiAfterCompletion(false);
-        BPELMain.main(engine, "sequence", "-f", "test-" + engine);
-        assertEquals("[Sequence;" + engine + ";structured;1;0;1;1]", Files.readAllLines(Paths.get("test-" + engine + "/reports/results.csv")).toString());
+        BPELMain.main(engine, process, "-f", "test-" + engine);
+        assertEquals("[" + process + ";" + engine + ";structured;1;0;1;1]", Files.readAllLines(Paths.get("test-" + engine + "/reports/results.csv")).toString());
     }
 
 }

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -82,7 +82,7 @@ public class SystemTest {
 
     @Test
     public void test_B3_BpelBpelgInvokeSync() throws IOException, InterruptedException {
-        testBPELEngine("bpelg", "Invoke-Sync");
+        testBPELEngine("bpelg", "basic", "Invoke-Sync");
     }
 
     @Test
@@ -103,13 +103,13 @@ public class SystemTest {
     }
 
     private void testBPELEngine(String engine) throws IOException {
-        testBPELEngine(engine, "Sequence");
+        testBPELEngine(engine, "structured", "Sequence");
     }
 
-    private void testBPELEngine(String engine, String process) throws IOException {
+    private void testBPELEngine(String engine, String group, String process) throws IOException {
         BPELMain.shutdownSoapUiAfterCompletion(false);
         BPELMain.main(engine, process, "-f", "test-" + engine);
-        assertEquals("[" + process + ";" + engine + ";structured;1;0;1;1]", Files.readAllLines(Paths.get("test-" + engine + "/reports/results.csv")).toString());
+        assertEquals("[" + process + ";" + engine + ";" + group + ";1;0;1;1]", Files.readAllLines(Paths.get("test-" + engine + "/reports/results.csv")).toString());
     }
 
 }

--- a/src/test/groovy/betsy/SystemTest.java
+++ b/src/test/groovy/betsy/SystemTest.java
@@ -62,7 +62,6 @@ public class SystemTest {
         assertEquals("[Sequence;wso2_v3_2_0;structured;1;0;1;1]", Files.readAllLines(Paths.get("test-wso320/reports/results.csv")).toString());
     }
 
-    @Ignore
     @Test
     public void test_B5_BpelActiveBpelSequence() throws IOException, InterruptedException {
         BPELMain.shutdownSoapUiAfterCompletion(true);


### PR DESCRIPTION
+ active-bpel
+ ode, ode136, ode-in-memory, ode136-in-memory
+ bpelg, bpelg-in-memory
+ camunda in all versions
+ activiti in all versions
+ openesb301standalone
+ wso2 3.0, 3.1 and 3.2 (not 2.1.2)

=> ca. 5% more test coverage