### PR TITLE
Ignore unstable tests

### DIFF
--- a/src/test/groovy/betsy/BPELSystemTest.java
+++ b/src/test/groovy/betsy/BPELSystemTest.java
@@ -116,7 +116,7 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("petalsesb");
     }
 
-    @Test
+    @Test @Ignore("unstable")
     public void test_B7_BpelPetalsesb41Sequence() throws IOException, InterruptedException {
         testBPELEngine("petalsesb41");
     }

--- a/src/test/groovy/betsy/BPELSystemTest.java
+++ b/src/test/groovy/betsy/BPELSystemTest.java
@@ -91,7 +91,7 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("openesb301standalone");
     }
 
-    @Test @Ignore("older revision")
+    @Test
     public void test_B5_B2_BpelOpenesb23Sequence() throws IOException, InterruptedException {
         testBPELEngine("openesb23");
     }

--- a/src/test/groovy/betsy/BPELSystemTest.java
+++ b/src/test/groovy/betsy/BPELSystemTest.java
@@ -71,12 +71,12 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("wso2_v2_1_2");
     }
 
-    @Test
+    @Test @Ignore("older revision")
     public void test_B4_BpelWso300Sequence() throws IOException, InterruptedException {
         testBPELEngine("wso2_v3_0_0");
     }
 
-    @Test
+    @Test @Ignore("older revision")
     public void test_B4_BpelWso310Sequence() throws IOException, InterruptedException {
         testBPELEngine("wso2_v3_1_0");
     }
@@ -91,7 +91,7 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("openesb301standalone");
     }
 
-    @Test
+    @Test @Ignore("older revision")
     public void test_B5_B2_BpelOpenesb23Sequence() throws IOException, InterruptedException {
         testBPELEngine("openesb23");
     }
@@ -101,7 +101,7 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("openesb231");
     }
 
-    @Test
+    @Test @Ignore("older revision")
     public void test_B5__B1_BpelOpenesbSequence() throws IOException, InterruptedException {
         testBPELEngine("openesb");
     }
@@ -111,12 +111,12 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("active-bpel");
     }
 
-    @Test
+    @Test @Ignore("older revision, possibly unstable")
     public void test_B7_BpelPetalsesbSequence() throws IOException, InterruptedException {
         testBPELEngine("petalsesb");
     }
 
-    @Test
+    @Test @Ignore("possibly unstable")
     public void test_B7_BpelPetalsesb41Sequence() throws IOException, InterruptedException {
         testBPELEngine("petalsesb41");
     }

--- a/src/test/groovy/betsy/BPELSystemTest.java
+++ b/src/test/groovy/betsy/BPELSystemTest.java
@@ -116,7 +116,7 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("petalsesb");
     }
 
-    @Test @Ignore("possibly unstable")
+    @Test
     public void test_B7_BpelPetalsesb41Sequence() throws IOException, InterruptedException {
         testBPELEngine("petalsesb41");
     }

--- a/src/test/groovy/betsy/BPELSystemTest.java
+++ b/src/test/groovy/betsy/BPELSystemTest.java
@@ -101,7 +101,7 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("openesb231");
     }
 
-    @Test @Ignore("older revision")
+    @Test
     public void test_B5__B1_BpelOpenesbSequence() throws IOException, InterruptedException {
         testBPELEngine("openesb");
     }

--- a/src/test/groovy/betsy/BPELSystemTest.java
+++ b/src/test/groovy/betsy/BPELSystemTest.java
@@ -76,7 +76,7 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("wso2_v3_0_0");
     }
 
-    @Test @Ignore("older revision")
+    @Test
     public void test_B4_BpelWso310Sequence() throws IOException, InterruptedException {
         testBPELEngine("wso2_v3_1_0");
     }

--- a/src/test/groovy/betsy/BPELSystemTest.java
+++ b/src/test/groovy/betsy/BPELSystemTest.java
@@ -101,7 +101,7 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("openesb231");
     }
 
-    @Test
+    @Test @Ignore("unstable")
     public void test_B5__B1_BpelOpenesbSequence() throws IOException, InterruptedException {
         testBPELEngine("openesb");
     }

--- a/src/test/groovy/betsy/BPELSystemTest.java
+++ b/src/test/groovy/betsy/BPELSystemTest.java
@@ -71,7 +71,7 @@ public class BPELSystemTest extends AbstractSystemTest{
         testBPELEngine("wso2_v2_1_2");
     }
 
-    @Test @Ignore("older revision")
+    @Test
     public void test_B4_BpelWso300Sequence() throws IOException, InterruptedException {
         testBPELEngine("wso2_v3_0_0");
     }


### PR DESCRIPTION
It seems that petals irregularily crashes the build. We should, therefore, exclude it from the regular tests.