### PR TITLE
squid:S2131,squid:S2864 - Primitives should not be boxed just for Str…

### DIFF
--- a/src/main/groovy/betsy/bpel/tools/TestsPerGroup.java
+++ b/src/main/groovy/betsy/bpel/tools/TestsPerGroup.java
@@ -26,7 +26,7 @@ public class TestsPerGroup {
             } else if(size < 100) {
                 output.add("0" + size + "\t" + name );
             } else {
-                output.add("" + size + "\t" + name );
+                output.add(Integer.toString(size) + "\t" + name );
             }
 
         }

--- a/src/main/groovy/betsy/common/tasks/FileTasks.java
+++ b/src/main/groovy/betsy/common/tasks/FileTasks.java
@@ -28,7 +28,7 @@ public class FileTasks {
 
         String[] lines = content.split("\n");
 
-        String showOutput = "" + lines.length + " lines";
+        String showOutput = Integer.toString(lines.length) + " lines";
         if (lines.length < 5) {
             showOutput = content.replace("\n", "@LINE_BREAK@");
         }
@@ -362,10 +362,10 @@ public class FileTasks {
         Replace replaceTask = new Replace();
         replaceTask.setFile(targetFile.toFile());
 
-        for (String token : replacements.keySet()) {
-            String value = String.valueOf(replacements.get(token));
+        for (Map.Entry<String, ?> stringEntry : replacements.entrySet()) {
+            String value = String.valueOf(stringEntry.getValue());
             Replace.Replacefilter filter = replaceTask.createReplacefilter();
-            filter.setToken(token);
+            filter.setToken(stringEntry.getKey());
             filter.setValue(value);
         }
 
@@ -390,10 +390,10 @@ public class FileTasks {
         Replace replaceTask = new Replace();
         replaceTask.setDir(targetFile.toFile());
 
-        for (String token : replacements.keySet()) {
-            String value = String.valueOf(replacements.get(token));
+        for (Map.Entry<String, ?> stringEntry : replacements.entrySet()) {
+            String value = String.valueOf(stringEntry.getValue());
             Replace.Replacefilter filter = replaceTask.createReplacefilter();
-            filter.setToken(token);
+            filter.setToken(stringEntry.getKey());
             filter.setValue(value);
         }
 

--- a/src/main/groovy/betsy/common/util/Progress.java
+++ b/src/main/groovy/betsy/common/util/Progress.java
@@ -20,7 +20,7 @@ public class Progress {
      * @return "current/max"
      */
     public String toString() {
-        return "" + current + "/" + max;
+        return Integer.toString(current) + "/" + max;
     }
 
 }

--- a/src/main/groovy/betsy/common/util/Stopwatch.java
+++ b/src/main/groovy/betsy/common/util/Stopwatch.java
@@ -28,7 +28,7 @@ public class Stopwatch {
      * @return raw diff in seconds seconds.
      */
     public String getSecondsDiff() {
-        return "" + (getDiff() / 1000);
+        return Long.toString((getDiff() / 1000));
     }
 
     public String toString() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2131 - Primitives should not be boxed just for "String" conversion
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat