### PR TITLE
squid:S2162, squid:S1941, squid:S1157

### DIFF
--- a/src/main/groovy/betsy/EngineMain.java
+++ b/src/main/groovy/betsy/EngineMain.java
@@ -25,7 +25,7 @@ public class EngineMain {
             return;
         }
 
-        String engineName = args[0];
+
         String commandName = args[1];
 
         Consumer<EngineLifecycle> command = commands.get(commandName);
@@ -33,6 +33,8 @@ public class EngineMain {
             usage();
             return;
         }
+
+        String engineName = args[0];
 
         Optional<EngineLifecycle> engine = getEngines().stream().filter((e) -> e.toString().equalsIgnoreCase(engineName)).findFirst();
         if (!engine.isPresent()) {

--- a/src/main/groovy/betsy/bpel/virtual/host/virtualbox/VirtualBoxMachineImpl.java
+++ b/src/main/groovy/betsy/bpel/virtual/host/virtualbox/VirtualBoxMachineImpl.java
@@ -222,7 +222,6 @@ public class VirtualBoxMachineImpl implements VirtualBoxMachine {
 
             subSession = vbManager.getSessionObject();
             machine.lockMachine(subSession, LockType.Write);
-            IConsole console = subSession.getConsole();
 
             ISnapshot snapshot = machine.getCurrentSnapshot();
             if (snapshot == null) {
@@ -231,6 +230,7 @@ public class VirtualBoxMachineImpl implements VirtualBoxMachine {
                         + "snapshot.");
             }
 
+            IConsole console = subSession.getConsole();
             waitForCompletion(console.restoreSnapshot(snapshot), Timeouts.THIRTY_SECONDS);
 
             log.trace("State after restoration:" + machine.getState());

--- a/src/main/groovy/betsy/bpmn/validation/BPMNValidator.java
+++ b/src/main/groovy/betsy/bpmn/validation/BPMNValidator.java
@@ -53,7 +53,7 @@ public class BPMNValidator {
                 String expectedTargetNamespace = "http://dsg.wiai.uniba.de/betsy/bpmn/"+process.getName();
                 XPathExpression targetNamespaceExpression = xpath.compile("//*[local-name() = 'definitions']/@targetNamespace");
                 nodeList = (NodeList) targetNamespaceExpression.evaluate(doc, XPathConstants.NODESET);
-                if (nodeList.getLength() != 1 && expectedTargetNamespace.toLowerCase().equals(nodeList.item(0).getTextContent().toLowerCase())) {
+                if (nodeList.getLength() != 1 && expectedTargetNamespace.equalsIgnoreCase(nodeList.item(0).getTextContent())) {
                     throw new IllegalStateException("targetNamespace of definitions element of process '" + process.getName() + " is not '"+expectedTargetNamespace+"'");
                 }
 

--- a/src/main/groovy/betsy/common/repositories/Repository.java
+++ b/src/main/groovy/betsy/common/repositories/Repository.java
@@ -25,7 +25,7 @@ public class Repository<T> {
 
     public List<T> getByName(final String name) {
         String trimmedName = name.trim();
-        final String key = repository.keySet().stream().filter(t -> t.toUpperCase().equals(trimmedName.toUpperCase())).findFirst().orElse(trimmedName);
+        final String key = repository.keySet().stream().filter(t -> t.equalsIgnoreCase(trimmedName)).findFirst().orElse(trimmedName);
 
         if (!repository.containsKey(key)) {
             throw new IllegalArgumentException("Name '" + key + "' does not exist in repository.");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2162 - "equals" methods should be symmetric and work for subclasses
squid:S1941 - Variables should not be declared before they are relevant
squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1157

Please let me know if you have any questions.

M-Ezzat