### PR TITLE
squid:S2325 - private methods that don't access instance data should …

### DIFF
--- a/src/main/groovy/betsy/bpel/engines/petalsesb/PetalsEsbDeployer.java
+++ b/src/main/groovy/betsy/bpel/engines/petalsesb/PetalsEsbDeployer.java
@@ -30,7 +30,7 @@ public class PetalsEsbDeployer {
         );
     }
 
-    private String getFileName(String processName) {
+    private static String getFileName(String processName) {
         return processName + "Application.zip";
     }
 

--- a/src/main/groovy/betsy/bpel/virtual/host/virtualbox/SnapshotCreator.java
+++ b/src/main/groovy/betsy/bpel/virtual/host/virtualbox/SnapshotCreator.java
@@ -129,7 +129,7 @@ public class SnapshotCreator {
         return EngineNamingConstants.VIRTUAL_NAME_PREFIX + engineName + "_import-snapshot";
     }
 
-    private String createSnapshotDescription() {
+    private static String createSnapshotDescription() {
         Date date = new Date();
         SimpleDateFormat sdf = new SimpleDateFormat("EEE, d MMM yyyy HH:mm");
         return "Machine is in 'saved' state. Snapshot created during import on " + sdf.format(date);

--- a/src/main/groovy/betsy/bpmn/reporting/BPMNTestcaseMerger.java
+++ b/src/main/groovy/betsy/bpmn/reporting/BPMNTestcaseMerger.java
@@ -145,7 +145,7 @@ public class BPMNTestcaseMerger {
         createAggregatedTestSuite(doc);
     }
 
-    private Document parseFile(Path file, DocumentBuilder dBuilder) throws IOException {
+    private static Document parseFile(Path file, DocumentBuilder dBuilder) throws IOException {
         try {
             return dBuilder.parse(file.toFile());
         } catch (SAXException e) {
@@ -153,7 +153,7 @@ public class BPMNTestcaseMerger {
         }
     }
 
-    private DocumentBuilder createDocumentBuilder() {
+    private static DocumentBuilder createDocumentBuilder() {
         try {
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
             return dbFactory.newDocumentBuilder();
@@ -177,7 +177,7 @@ public class BPMNTestcaseMerger {
     /**
      * // remove "Test-" from the file names
      */
-    private void removePrefixOfTestResults(Path path) {
+    private static void removePrefixOfTestResults(Path path) {
         try {
             Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
                 @Override

--- a/src/main/groovy/betsy/bpmn/reporting/TestCaseToLatexSerializer.java
+++ b/src/main/groovy/betsy/bpmn/reporting/TestCaseToLatexSerializer.java
@@ -119,7 +119,7 @@ public class TestCaseToLatexSerializer {
         println("\\end{center}");
     }
 
-    private void println(String line) {
+    private static void println(String line) {
         System.out.println(line);
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat