### PR TITLE
squid:S3052 - Fields should not be initialized to default values

### DIFF
--- a/src/main/groovy/betsy/bpel/virtual/host/engines/AbstractVirtualBPELEngine.java
+++ b/src/main/groovy/betsy/bpel/virtual/host/engines/AbstractVirtualBPELEngine.java
@@ -60,7 +60,7 @@ public abstract class AbstractVirtualBPELEngine extends AbstractBPELEngine imple
         return new Engine(ProcessLanguage.BPEL, engineId.getName(), engineId.getVersion(), configuration);
     }
 
-    private VirtualBoxMachine vm = null;
+    private VirtualBoxMachine vm;
 
     public void setVirtualBox(VirtualBox virtualBox) {
         this.virtualBox = virtualBox;

--- a/src/main/groovy/betsy/bpel/virtual/host/virtualbox/VBoxConnector.java
+++ b/src/main/groovy/betsy/bpel/virtual/host/virtualbox/VBoxConnector.java
@@ -20,10 +20,10 @@ class VBoxConnector {
 
     private final VirtualBoxManager vBoxManager;
 
-    private IVirtualBox vBox = null;
-    private VBoxApplianceImporter vBoxImporter = null;
+    private IVirtualBox vBox;
+    private VBoxApplianceImporter vBoxImporter;
 
-    private boolean isConnected = false;
+    private boolean isConnected;
 
     public VBoxConnector() {
         this.vBoxManager = VirtualBoxManager.createInstance(null);

--- a/src/main/groovy/betsy/bpmn/reporting/BPMNTestcaseMerger.java
+++ b/src/main/groovy/betsy/bpmn/reporting/BPMNTestcaseMerger.java
@@ -28,13 +28,13 @@ public class BPMNTestcaseMerger {
 
     static class MergeResult {
         String name = "";
-        int errors = 0;
-        int failures = 0;
-        int skipped = 0;
-        int tests = 0;
-        double time = 0.0;
+        int errors;
+        int failures;
+        int skipped;
+        int tests;
+        double time;
         List<Node> testCases = new ArrayList<>();
-        Node properties = null;
+        Node properties;
     }
 
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3052 - Fields should not be initialized to default values

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat