### PR TITLE
squid:S1170 - Public constants and fields initialized at declaration …

### DIFF
--- a/src/main/groovy/betsy/bpmn/engines/jbpm/JbpmDeployer.java
+++ b/src/main/groovy/betsy/bpmn/engines/jbpm/JbpmDeployer.java
@@ -9,8 +9,8 @@ public class JbpmDeployer {
     private static final Logger LOGGER = Logger.getLogger(JbpmDeployer.class);
 
     private final String deploymentId;
-    private final String user = "admin";
-    private final String password = "admin";
+    private static final String USER = "admin";
+    private static final String PASSWORD = "admin";
     private final String baseUrl;
 
     public JbpmDeployer(String baseUrl, String deploymentId) {
@@ -21,7 +21,7 @@ public class JbpmDeployer {
     public void deploy() {
         LOGGER.info("Trying to deploy process \"" + deploymentId + "\".");
         try {
-            JsonHelper.postWithAuthWithAcceptJson(baseUrl + "/rest/deployment/" + deploymentId + "/deploy", 202, user, password);
+            JsonHelper.postWithAuthWithAcceptJson(baseUrl + "/rest/deployment/" + deploymentId + "/deploy", 202, USER, PASSWORD);
         } catch (RuntimeException e) {
             LOGGER.error("Deployment failure", e);
         }
@@ -30,7 +30,7 @@ public class JbpmDeployer {
     public void undeploy() {
         LOGGER.info("Trying to undeploy process \"" + deploymentId + "\".");
         try {
-            JsonHelper.postWithAuthWithAcceptJson(baseUrl + "/rest/deployment/" + deploymentId + "/undeploy", 202, user, password);
+            JsonHelper.postWithAuthWithAcceptJson(baseUrl + "/rest/deployment/" + deploymentId + "/undeploy", 202, USER, PASSWORD);
         } catch (RuntimeException e) {
             LOGGER.error("Undeployment failure", e);
         }
@@ -41,7 +41,7 @@ public class JbpmDeployer {
 
         try {
 
-            JSONObject object = JsonHelper.getJSONWithAuth(baseUrl + "/rest/deployment/" + deploymentId, 200, user, password);
+            JSONObject object = JsonHelper.getJSONWithAuth(baseUrl + "/rest/deployment/" + deploymentId, 200, USER, PASSWORD);
             String status = object.getString("status");
             return status != null && "DEPLOYED".equals(status);
 

--- a/src/main/groovy/betsy/bpmn/reporting/TestCaseToLatexSerializer.java
+++ b/src/main/groovy/betsy/bpmn/reporting/TestCaseToLatexSerializer.java
@@ -14,11 +14,11 @@ import java.util.Optional;
  */
 public class TestCaseToLatexSerializer {
 
-    private final String TABLE_NEWLINE = "\\\\";
+    private static final String TABLE_NEWLINE = "\\\\";
 
-    private final String ROW_COLOUR = "\\myrowcolour";
+    private static final String ROW_COLOUR = "\\myrowcolour";
 
-    private final String COLOUR_NEXT_ROW = TABLE_NEWLINE + ROW_COLOUR;
+    private static final String COLOUR_NEXT_ROW = TABLE_NEWLINE + ROW_COLOUR;
 
     public static void main(String... args) {
         new TestCaseToLatexSerializer().buildTableFromProcesses(new BPMNProcessRepository().getByName("ALL"));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1170 - Public constants and fields initialized at declaration should be "static final" rather than merely "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1170

Please let me know if you have any questions.

M-Ezzat