### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/groovy/betsy/AnalyticsMain.java
+++ b/src/main/groovy/betsy/AnalyticsMain.java
@@ -7,7 +7,9 @@ import configuration.bpmn.BPMNProcessRepository;
 
 import java.nio.file.Paths;
 
-public class AnalyticsMain {
+public final class AnalyticsMain {
+
+    private AnalyticsMain() {}
 
     public static void main(String... args) {
         if ("dashboard".equalsIgnoreCase(args[0])) {

--- a/src/main/groovy/betsy/EngineMain.java
+++ b/src/main/groovy/betsy/EngineMain.java
@@ -8,9 +8,11 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-public class EngineMain {
+public final class EngineMain {
 
     private static Map<String, Consumer<EngineLifecycle>> commands = new HashMap<>();
+
+    private EngineMain() {}
 
     public static void main(String... args) {
         commands.put("install", EngineLifecycle::install);

--- a/src/main/groovy/betsy/Main.java
+++ b/src/main/groovy/betsy/Main.java
@@ -4,7 +4,9 @@ import betsy.bpel.BPELMain;
 import betsy.bpmn.BPMNMain;
 import betsy.tools.JsonGenerator;
 
-public class Main {
+public final class Main {
+
+    private Main() {}
 
     public static void main(String... args) {
         if (args.length == 0) {

--- a/src/main/groovy/betsy/ProcessMain.java
+++ b/src/main/groovy/betsy/ProcessMain.java
@@ -3,7 +3,9 @@ package betsy;
 import configuration.bpel.BPELProcessRepository;
 import configuration.bpmn.BPMNProcessRepository;
 
-public class ProcessMain {
+public final class ProcessMain {
+
+    private ProcessMain() {}
 
     public static void main(String... args) {
         if ("bpel".equalsIgnoreCase(args[0])) {

--- a/src/main/groovy/betsy/bpel/BPELMain.java
+++ b/src/main/groovy/betsy/bpel/BPELMain.java
@@ -30,11 +30,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class BPELMain {
+public final class BPELMain {
 
     private static final Logger LOGGER = Logger.getLogger(BPELMain.class);
 
     private static boolean shouldShutdownSoapUi = true;
+
+    private BPELMain() {}
 
     public static void main(String... args) {
         activateLogging();

--- a/src/main/groovy/betsy/bpel/corebpel/CoreBPELEngineExtension.java
+++ b/src/main/groovy/betsy/bpel/corebpel/CoreBPELEngineExtension.java
@@ -6,7 +6,10 @@ import corebpel.CoreBPEL;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class CoreBPELEngineExtension {
+public final class CoreBPELEngineExtension {
+
+    private CoreBPELEngineExtension() {}
+
     public static void extendEngine(AbstractBPELEngine engine, final List<String> transformations) {
         assertValidTransformations(transformations);
         engine.setPackageBuilder(new CoreBPELBPELEnginePackageBuilder(transformations));

--- a/src/main/groovy/betsy/bpel/engines/bpelg/Util.java
+++ b/src/main/groovy/betsy/bpel/engines/bpelg/Util.java
@@ -9,7 +9,9 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class Util {
+public final class Util {
+
+    private Util() {}
 
     public static List<String> computeMatchingPattern(BPELProcess process) {
         // This method works based on the knowledge that we have no more than two operations available anyway

--- a/src/main/groovy/betsy/bpel/soapui/SoapUIShutdownHelper.java
+++ b/src/main/groovy/betsy/bpel/soapui/SoapUIShutdownHelper.java
@@ -7,7 +7,9 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.concurrent.TimeUnit;
 
-public class SoapUIShutdownHelper {
+public final class SoapUIShutdownHelper {
+
+    private SoapUIShutdownHelper() {}
 
     public static void shutdownSoapUIForReal() {
         SoapUI.shutdown();

--- a/src/main/groovy/betsy/bpel/soapui/SoapUiAssertionBuilder.java
+++ b/src/main/groovy/betsy/bpel/soapui/SoapUiAssertionBuilder.java
@@ -20,7 +20,10 @@ import com.eviware.soapui.impl.wsdl.teststeps.registry.GroovyScriptStepFactory;
 
 import java.util.Objects;
 
-public class SoapUiAssertionBuilder {
+public final class SoapUiAssertionBuilder {
+
+    private SoapUiAssertionBuilder() {}
+
     public static void addSynchronousAssertion(SoapTestStep testStep, WsdlTestRequestStep soapUiRequest, WsdlTestCase soapUITestCase, int testStepNumber) {
         for (TestAssertion assertion : testStep.getAssertions()) {
 

--- a/src/main/groovy/betsy/bpel/soapui/TestMessages.java
+++ b/src/main/groovy/betsy/bpel/soapui/TestMessages.java
@@ -1,6 +1,8 @@
 package betsy.bpel.soapui;
 
-public class TestMessages {
+public final class TestMessages {
+
+    private TestMessages() {}
 
     public static String createSyncTestPartnerInputMessage(String input) {
         return "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +

--- a/src/main/groovy/betsy/bpel/tools/CoreBPELEnumerator.java
+++ b/src/main/groovy/betsy/bpel/tools/CoreBPELEnumerator.java
@@ -14,7 +14,10 @@ import java.util.List;
 /**
  * Applies all CoreBPEL transformations separately on every BPEL test case. The output is stored in corebpel-results.
  */
-public class CoreBPELEnumerator {
+public final class CoreBPELEnumerator {
+
+    private CoreBPELEnumerator() {}
+
     public static void main(String... args) throws IOException, TransformerException {
         Path outputFolder = Paths.get("corebpel-results");
 

--- a/src/main/groovy/betsy/bpel/tools/TestsPerGroup.java
+++ b/src/main/groovy/betsy/bpel/tools/TestsPerGroup.java
@@ -9,7 +9,9 @@ import java.util.List;
 /**
  * Prints the processes per process group to the console.
  */
-public class TestsPerGroup {
+public final class TestsPerGroup {
+
+    private TestsPerGroup() {}
 
     public static void main(String... args) {
 

--- a/src/main/groovy/betsy/bpel/virtual/host/engines/EngineNamingConstants.java
+++ b/src/main/groovy/betsy/bpel/virtual/host/engines/EngineNamingConstants.java
@@ -1,5 +1,9 @@
 package betsy.bpel.virtual.host.engines;
 
-public class EngineNamingConstants {
+public final class EngineNamingConstants {
+
     public static final String VIRTUAL_NAME_PREFIX = "betsy-";
+
+    private EngineNamingConstants() {}
+
 }

--- a/src/main/groovy/betsy/bpel/virtual/host/virtualbox/utils/ServiceValidator.java
+++ b/src/main/groovy/betsy/bpel/virtual/host/virtualbox/utils/ServiceValidator.java
@@ -15,7 +15,9 @@ import java.util.List;
  * @author Cedric Roeck
  * @version 1.0
  */
-public class ServiceValidator {
+public final class ServiceValidator {
+
+    private ServiceValidator() {}
 
     /**
      * Check whether the {@link AbstractBPELEngine} is ready for usage.

--- a/src/main/groovy/betsy/bpel/virtual/host/virtualbox/utils/port/PortVerifier.java
+++ b/src/main/groovy/betsy/bpel/virtual/host/virtualbox/utils/port/PortVerifier.java
@@ -12,7 +12,9 @@ import java.util.Collection;
  * @author Cedric Roeck
  * @version 1.0
  */
-public class PortVerifier {
+public final class PortVerifier {
+
+	private PortVerifier() {}
 
 	private static void failForUnreachablePort(final int portNumber) throws PortUsageException{
 		try (ServerSocket serverSocket = new ServerSocket(portNumber);

--- a/src/main/groovy/betsy/bpel/virtual/server/logic/CollectLogFilesOperation.java
+++ b/src/main/groovy/betsy/bpel/virtual/server/logic/CollectLogFilesOperation.java
@@ -20,9 +20,11 @@ import java.util.List;
  * @author Cedric Roeck
  * @version 1.0
  */
-public class CollectLogFilesOperation {
+public final class CollectLogFilesOperation {
 
     private static final Logger log = Logger.getLogger(CollectLogFilesOperation.class);
+
+    private CollectLogFilesOperation() {}
 
     /**
      * Collect the log files of an engine and the betsy server. The directories

--- a/src/main/groovy/betsy/bpel/virtual/server/logic/DeployOperation.java
+++ b/src/main/groovy/betsy/bpel/virtual/server/logic/DeployOperation.java
@@ -20,9 +20,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public class DeployOperation {
+public final class DeployOperation {
 
     private final static Logger log = Logger.getLogger(DeployOperation.class);
+
+    private DeployOperation() {}
 
     public static DeployResponse deployOperation(DeployRequest request) throws DeployException, ChecksumException, ConnectionException {
         if (request.getFileMessage().isInvalid()) {

--- a/src/main/groovy/betsy/bpmn/BPMNMain.java
+++ b/src/main/groovy/betsy/bpmn/BPMNMain.java
@@ -14,9 +14,11 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class BPMNMain {
+public final class BPMNMain {
 
     private static final Logger LOGGER = Logger.getLogger(BPMNMain.class);
+
+    private BPMNMain() {}
 
     public static void main(String... args) {
         activateLogging();

--- a/src/main/groovy/betsy/bpmn/engines/BPMNEnginesUtil.java
+++ b/src/main/groovy/betsy/bpmn/engines/BPMNEnginesUtil.java
@@ -14,9 +14,11 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BPMNEnginesUtil {
+public final class BPMNEnginesUtil {
 
     private static final Logger LOGGER = Logger.getLogger(BPMNEnginesUtil.class);
+
+    private BPMNEnginesUtil() {}
 
     public static void substituteSpecificErrorsForGenericError(BPMNTestCase testCase, Path logDir) {
         if (testCase.getAssertions().contains(BPMNAssertions.ERROR_GENERIC.toString())) {

--- a/src/main/groovy/betsy/bpmn/engines/JsonHelper.java
+++ b/src/main/groovy/betsy/bpmn/engines/JsonHelper.java
@@ -13,7 +13,7 @@ import org.json.JSONObject;
 
 import java.nio.file.Path;
 
-public class JsonHelper {
+public final class JsonHelper {
 
     private static final Logger log = Logger.getLogger(JsonHelper.class);
 
@@ -24,6 +24,8 @@ public class JsonHelper {
     }
 
     public static final String REST_CALL_FAILED_WITH_URL = "rest call failed with url ";
+
+    private JsonHelper() {}
 
     public static JSONObject get(String url, int expectedCode) {
         log.info("HTTP GET " + url);

--- a/src/main/groovy/betsy/common/aggregation/AggregationRules.java
+++ b/src/main/groovy/betsy/common/aggregation/AggregationRules.java
@@ -2,7 +2,7 @@ package betsy.common.aggregation;
 
 import static java.util.Objects.requireNonNull;
 
-public class AggregationRules {
+public final class AggregationRules {
 
     public static AggregationRule<Boolean, TrivalentResult> GO_BIG_OR_GO_HOME = values -> {
         if(requireNonNull(values).stream().allMatch(i -> i)) {
@@ -32,5 +32,6 @@ public class AggregationRules {
      */
     public static AggregationRule<TrivalentResult, TrivalentResult> BEST = values -> requireNonNull(values).stream().sorted().findFirst().orElse(TrivalentResult.MINUS);
 
+    private AggregationRules() {}
 
 }

--- a/src/main/groovy/betsy/common/config/Configuration.java
+++ b/src/main/groovy/betsy/common/config/Configuration.java
@@ -11,11 +11,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 
-public class Configuration {
+public final class Configuration {
 
     private static final Logger log = Logger.getLogger(Configuration.class);
 
     public static final Properties PROPERTIES;
+
+    private Configuration() {}
 
     /**
      * Get the value of the given key.

--- a/src/main/groovy/betsy/common/logging/LogContext.java
+++ b/src/main/groovy/betsy/common/logging/LogContext.java
@@ -5,7 +5,7 @@ import org.apache.log4j.MDC;
 
 import java.util.Objects;
 
-public class LogContext {
+public final class LogContext {
 
     public static final String CONTEXT_KEY_PATH = "path";
 
@@ -13,6 +13,8 @@ public class LogContext {
         // default log context is BETSY
         MDC.put(CONTEXT_KEY_PATH, "betsy");
     }
+
+    private LogContext() {}
 
     public static String getContext() {
         Object context = MDC.get(CONTEXT_KEY_PATH);

--- a/src/main/groovy/betsy/common/model/engine/EngineDetails.java
+++ b/src/main/groovy/betsy/common/model/engine/EngineDetails.java
@@ -3,7 +3,9 @@ package betsy.common.model.engine;
 import java.util.HashMap;
 import java.util.Map;
 
-public class EngineDetails {
+public final class EngineDetails {
+
+    private EngineDetails() {}
 
     public static Map<String, String> getEngineToURL() {
         Map<String, String> result = new HashMap<>();

--- a/src/main/groovy/betsy/common/tasks/AntUtil.java
+++ b/src/main/groovy/betsy/common/tasks/AntUtil.java
@@ -6,8 +6,10 @@ import org.apache.tools.ant.BuildListener;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.listener.Log4jListener;
 
-public class AntUtil {
+public final class AntUtil {
     private static AntBuilder ant;
+
+    private AntUtil() {}
 
     public static AntBuilder builder() {
         if (ant == null) {

--- a/src/main/groovy/betsy/common/tasks/ConsoleTasks.java
+++ b/src/main/groovy/betsy/common/tasks/ConsoleTasks.java
@@ -10,10 +10,12 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.StringJoiner;
 
-public class ConsoleTasks {
+public final class ConsoleTasks {
     private static final Logger log = Logger.getLogger(ConsoleTasks.class);
     public static final String WINDOWS = "windows";
     public static final String UNIX = "unix";
+
+    private ConsoleTasks() {}
 
     public static void executeOnWindows(CliCommand cliCommand) {
         execute(WINDOWS, cliCommand, true, Collections.emptyMap());

--- a/src/main/groovy/betsy/common/tasks/FileTasks.java
+++ b/src/main/groovy/betsy/common/tasks/FileTasks.java
@@ -16,9 +16,11 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
 
-public class FileTasks {
+public final class FileTasks {
 
     private static final Logger LOGGER = Logger.getLogger(FileTasks.class);
+
+    private FileTasks() {}
 
     public static void createFile(Path file, String content) {
         mkdirs(file.getParent());

--- a/src/main/groovy/betsy/common/tasks/NetworkTasks.java
+++ b/src/main/groovy/betsy/common/tasks/NetworkTasks.java
@@ -7,9 +7,11 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public class NetworkTasks {
+public final class NetworkTasks {
 
     public static final String BETSY_SVN_BASE_URL = "https://lspi.wiai.uni-bamberg.de/svn/betsy/";
+
+    private NetworkTasks() {}
 
     public static void downloadFile(String url, Path fileOrFolder) {
         try {

--- a/src/main/groovy/betsy/common/tasks/PropertyTasks.java
+++ b/src/main/groovy/betsy/common/tasks/PropertyTasks.java
@@ -7,7 +7,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
-public class PropertyTasks {
+public final class PropertyTasks {
+
+    private PropertyTasks() {}
 
     public static void setPropertyInPropertiesFile(Path propertiesFile, String key, String value) {
         Properties properties = new Properties();

--- a/src/main/groovy/betsy/common/tasks/TrustModifier.java
+++ b/src/main/groovy/betsy/common/tasks/TrustModifier.java
@@ -8,11 +8,13 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
-public class TrustModifier {
+public final class TrustModifier {
 
         private static final TrustingHostnameVerifier
                 TRUSTING_HOSTNAME_VERIFIER = new TrustingHostnameVerifier();
         private static SSLSocketFactory factory;
+
+        private TrustModifier() {}
 
         /** Call this with any HttpURLConnection, and it will
          modify the trust settings if it is an HTTPS connection. */

--- a/src/main/groovy/betsy/common/tasks/URLTasks.java
+++ b/src/main/groovy/betsy/common/tasks/URLTasks.java
@@ -12,9 +12,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 
-public class URLTasks {
+public final class URLTasks {
 
     private static final Logger LOGGER = Logger.getLogger(URLTasks.class);
+
+    private URLTasks() {}
 
     public static boolean isUrlAvailable(URL url) {
         LOGGER.info("Checking whether the url " + url + " returns HTTP 200");

--- a/src/main/groovy/betsy/common/tasks/WaitTasks.java
+++ b/src/main/groovy/betsy/common/tasks/WaitTasks.java
@@ -7,9 +7,11 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
-public class WaitTasks {
+public final class WaitTasks {
 
     private static final Logger LOGGER = Logger.getLogger(WaitTasks.class);
+
+    private WaitTasks() {}
 
     /**
      * Sleeps/waits for a specific amount of milliseconds.

--- a/src/main/groovy/betsy/common/tasks/XSLTTasks.java
+++ b/src/main/groovy/betsy/common/tasks/XSLTTasks.java
@@ -5,7 +5,9 @@ import org.apache.tools.ant.taskdefs.XSLTProcess;
 
 import java.nio.file.Path;
 
-public class XSLTTasks {
+public final class XSLTTasks {
+
+    private XSLTTasks() {}
 
     public static void transform(Path xslt, Path input, Path output) {
         createXSLTProcess(xslt, input, output).execute();

--- a/src/main/groovy/betsy/common/tasks/ZipTasks.java
+++ b/src/main/groovy/betsy/common/tasks/ZipTasks.java
@@ -6,9 +6,11 @@ import org.apache.tools.ant.taskdefs.Zip;
 
 import java.nio.file.Path;
 
-public class ZipTasks {
+public final class ZipTasks {
 
     private static final Logger LOGGER = Logger.getLogger(ZipTasks.class);
+
+    private ZipTasks() {}
 
     public static void zipFolder(Path tempZipFile, Path folder) {
         LOGGER.info("Creating zip archive " + tempZipFile + " using the contents of " + folder);

--- a/src/main/groovy/betsy/common/util/ClasspathHelper.java
+++ b/src/main/groovy/betsy/common/util/ClasspathHelper.java
@@ -6,7 +6,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
-public class ClasspathHelper {
+public final class ClasspathHelper {
+
+    private ClasspathHelper() {}
 
     public static Path getFilesystemPathFromClasspathPath(String classpathPath) {
         try {

--- a/src/main/groovy/betsy/common/util/CollectionsUtil.java
+++ b/src/main/groovy/betsy/common/util/CollectionsUtil.java
@@ -3,7 +3,10 @@ package betsy.common.util;
 import java.util.LinkedList;
 import java.util.List;
 
-public class CollectionsUtil {
+public final class CollectionsUtil {
+
+    private CollectionsUtil() {}
+
     public static <T> List<T> union(List<List<T>> collections) {
         if (collections.size() <= 0) {
             return new LinkedList<>();

--- a/src/main/groovy/betsy/common/util/FileTypes.java
+++ b/src/main/groovy/betsy/common/util/FileTypes.java
@@ -3,13 +3,15 @@ package betsy.common.util;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public class FileTypes {
+public final class FileTypes {
 
     public static final String BPEL = ".bpel";
     public static final String WSDL = ".wsdl";
     public static final String XSD = ".xsd";
     public static final String XSL = ".xsl";
     public static final String BPMN = ".bpmn";
+
+    private FileTypes() {}
 
     public static boolean isBpelFile(Path file) {
         return isFileWithSpecificExtension(file, BPEL);

--- a/src/main/groovy/betsy/common/util/GitUtil.java
+++ b/src/main/groovy/betsy/common/util/GitUtil.java
@@ -4,7 +4,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-public class GitUtil {
+public final class GitUtil {
+
+    private GitUtil() {}
 
     public static String getGitCommit() {
         Runtime rt = Runtime.getRuntime();

--- a/src/main/groovy/betsy/common/util/IOCapture.java
+++ b/src/main/groovy/betsy/common/util/IOCapture.java
@@ -5,8 +5,10 @@ import org.apache.log4j.Logger;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-public class IOCapture {
+public final class IOCapture {
     private static final Logger LOGGER = Logger.getLogger(IOCapture.class);
+
+    private IOCapture() {}
 
     public static void captureIO(Runnable closure) {
         //stdout

--- a/src/main/groovy/betsy/common/util/OperatingSystem.java
+++ b/src/main/groovy/betsy/common/util/OperatingSystem.java
@@ -1,9 +1,11 @@
 package betsy.common.util;
 
-public class OperatingSystem {
+public final class OperatingSystem {
 
     public static final String osName = System.getProperty("os.name", "unknown").toLowerCase();
     public static final boolean WINDOWS = osName.startsWith("win");
     public static final boolean NOT_WINDOWS = !WINDOWS;
+
+    private OperatingSystem() {}
 
 }

--- a/src/main/groovy/betsy/common/util/StringUtils.java
+++ b/src/main/groovy/betsy/common/util/StringUtils.java
@@ -2,7 +2,10 @@ package betsy.common.util;
 
 import java.nio.file.Path;
 
-public class StringUtils {
+public final class StringUtils {
+
+    private StringUtils() {}
+
     public static String capitalize(String self) {
         if (self == null || self.length() == 0) {
             return self;

--- a/src/main/groovy/betsy/tools/EngineControl.java
+++ b/src/main/groovy/betsy/tools/EngineControl.java
@@ -46,9 +46,11 @@ import java.util.stream.Collectors;
 /**
  * The GUI to install, start and stop a local engine or all local engines.
  */
-public class EngineControl extends Application {
+public final class EngineControl extends Application {
 
-    private static class LogFileUtil {
+    private static final class LogFileUtil {
+
+        private LogFileUtil() {}
 
         /**
          * Requires BPEL or BPMN Engine to be passed!

--- a/src/main/groovy/betsy/tools/EngineTableGenerator.java
+++ b/src/main/groovy/betsy/tools/EngineTableGenerator.java
@@ -20,7 +20,9 @@ import betsy.common.engines.EngineLifecycle;
 import betsy.common.model.engine.Engine;
 import betsy.common.model.engine.IsEngine;
 
-public class EngineTableGenerator {
+public final class EngineTableGenerator {
+
+    private EngineTableGenerator() {}
 
     public static void main(String[] args) {
         generateEnginesJson();

--- a/src/main/groovy/betsy/tools/JsonGenerator.java
+++ b/src/main/groovy/betsy/tools/JsonGenerator.java
@@ -42,9 +42,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class JsonGenerator {
+public final class JsonGenerator {
 
-    static class FeatureTreeJsonGenerator {
+    private JsonGenerator() {}
+
+    static final class FeatureTreeJsonGenerator {
+
+        private FeatureTreeJsonGenerator() {}
+
         private static void generatesConstructsJson() {
             JSONArray featureTree = new JSONArray();
 
@@ -129,7 +134,9 @@ public class JsonGenerator {
         }
     }
 
-    static class EnginesJsonGenerator {
+    static final class EnginesJsonGenerator {
+
+        private EnginesJsonGenerator() {}
 
         private static void generateEnginesJson() {
             JSONArray array = new JSONArray();
@@ -171,7 +178,10 @@ public class JsonGenerator {
         }
     }
 
-    static class TestsEngineIndependentJsonGenerator {
+    static final class TestsEngineIndependentJsonGenerator {
+
+        private TestsEngineIndependentJsonGenerator() {}
+
         private static void generateTestsEngineIndependentJson() {
             JSONArray array = new JSONArray();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat